### PR TITLE
Prevent empty searches { Original author: @losingkeys }

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -41,6 +41,11 @@ function! ag#Ag(cmd, args)
     let l:grepargs = a:args . join(a:000, ' ')
   end
 
+  if empty(l:grepargs)
+    echo "Usage: ':Ag {pattern}'. See ':help :Ag' for more information."
+    return
+  endif
+
   " Format, used to manage column jump
   if a:cmd =~# '-g$'
     let s:agformat_backup=g:agformat


### PR DESCRIPTION
Previously `:Ag` (with nothing under the cursor; e.g. an empty buffer)
would open the quickfix window with "ERR: What do you want to search
for?", which wasn't as helpful, and it left a useless quickfix window
open.

Closes #51
