### PR TITLE
Fix for guessProjectRoot() on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Vim has various ways of installing plugins, the standard way is in [the document
 
 You can specify a custom ag name and path in your .vimrc like so:
 
-    let g:agprg="<custom-ag-path-goes-here> --vimgrep"
+    let g:ag_prg="<custom-ag-path-goes-here> --vimgrep"
 
 You can configure ag.vim to always start searching from your project root
 instead of the cwd

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -216,24 +216,18 @@ function! ag#AgHelp(cmd,args)
 endfunction
 
 function! s:guessProjectRoot()
-  let l:splitsign = '/'
-  for l:os in ['win16', 'win32', 'win64']
-    if has(l:os)
-      let l:splitsign = '\'
-      break
-    endif
-  endfor
-  let l:splitsearchdir = split(getcwd(), l:splitsign)
+  let l:searchdir = getcwd()
 
-  while len(l:splitsearchdir) > 2
-    let l:searchdir = l:splitsign.join(l:splitsearchdir, l:splitsign).l:splitsign
+  while len(l:searchdir) > 2
     for l:marker in ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml']
-      " found it! Return the dir
-      if filereadable(l:searchdir.l:marker) || isdirectory(l:searchdir.l:marker)
+      " the forward slash works as a dirsep on Windows too.
+      let l:item = l:searchdir.'/'.l:marker
+      if filereadable(l:item) || isdirectory(l:item)
+        " found it! Return the dir
         return l:searchdir
       endif
     endfor
-    let l:splitsearchdir = l:splitsearchdir[0:-2] " Splice the list to get rid of the tail directory
+    let l:searchdir = substitute(l:searchdir, '\(.*\)[\\/][^\\/]*$', '\1', "")
   endwhile
 
   " Nothing found, fallback to current working dir

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -218,6 +218,7 @@ endfunction
 function! s:guessProjectRoot()
   let l:searchdir = getcwd()
 
+  " this code will find these directories or files at the root on Windows but not on other platforms
   while len(l:searchdir) > 2
     for l:marker in ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml']
       " the forward slash works as a dirsep on Windows too.

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -217,6 +217,9 @@ endfunction
 
 function! s:guessProjectRoot()
   let l:searchdir = getcwd()
+  if has('win16') || has('win32')
+      let l:searchdir = substitute(l:searchdir, '\', '/', 'g')
+  endif
 
   " this code will find these directories or files at the root on Windows but not on other platforms
   while len(l:searchdir) > 2
@@ -228,7 +231,7 @@ function! s:guessProjectRoot()
         return l:searchdir
       endif
     endfor
-    let l:searchdir = substitute(l:searchdir, '\(.*\)[\\/][^\\/]*$', '\1', "")
+    let l:searchdir = substitute(l:searchdir, '\(.*\)/[^/]*$', '\1', "")
   endwhile
 
   " Nothing found, fallback to current working dir

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -169,11 +169,12 @@ function! ag#Ag(cmd, args)
         echom "ag.vim keys: q=quit <cr>/e/t/h/v=enter/edit/tab/split/vsplit go/T/H/gv=preview versions of same"
       endif
     endif
-  else
-    echom 'No matches for "'.a:args.'"'
-    " Close the split window automatically:
+  else " Close the split window automatically:
     cclose
     lclose
+    echohl WarningMsg
+    echom 'No matches for "'.a:args.'"'
+    echohl None
   endif
 endfunction
 

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -171,6 +171,9 @@ function! ag#Ag(cmd, args)
     endif
   else
     echom 'No matches for "'.a:args.'"'
+    " Close the split window automatically:
+    cclose
+    lclose
   endif
 endfunction
 

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -1,17 +1,26 @@
 " NOTE: You must, of course, install ag / the_silver_searcher
 
-" FIXME: Delete deprecated options below on or after 15-7 (6 months from when they were changed) {{{
+" FIXME: Delete deprecated options below on or after 2016-4 (6 months from when the deprecation warning was added) {{{
 
 if exists("g:agprg")
   let g:ag_prg = g:agprg
+  echohl WarningMsg
+  call input('g:agprg is deprecated and will be removed. Please use g:ag_prg')
+  echohl None
 endif
 
 if exists("g:aghighlight")
   let g:ag_highlight = g:aghighlight
+  echohl WarningMsg
+  call input('g:aghighlight is deprecated and will be removed. Please use g:ag_highlight')
+  echohl None
 endif
 
 if exists("g:agformat")
   let g:ag_format = g:agformat
+  echohl WarningMsg
+  call input('g:agformat is deprecated and will be removed. Please use g:ag_format')
+  echohl None
 endif
 
 " }}} FIXME: Delete the deprecated options above on or after 15-7 (6 months from when they were changed)

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -88,6 +88,11 @@ function! ag#Ag(cmd, args)
     let l:grepargs = a:args . join(a:000, ' ')
   end
 
+  if empty(l:grepargs)
+    echo "Usage: ':Ag {pattern}' (or just :Ag to search for the word under the cursor). See ':help :Ag' for more information."
+    return
+  endif
+
   " Format, used to manage column jump
   if a:cmd =~# '-g$'
     let s:ag_format_backup=g:ag_format


### PR DESCRIPTION
Sorry, I'm new on github; it looks like I may not have done this quite right but this'll bring your branch up to date with the latest.

This patch removes the attempts at figuring out the dirsep and instead just chops off directories at forward or back slash. As the Windows file API supports forward slashes too, we just convert backslashes to forward right off the bat.
