### PR TITLE
Returns a trailing slash on the directory name holding project root

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -223,10 +223,10 @@ function! s:guessProjectRoot()
   let l:searchdirs = split(l:startdir, '/', 1)
 
   while len(l:searchdirs) > 0
-    let l:searchdir = join(l:searchdirs, '/')
+    " the forward slash works as a dirsep on Windows too.
+    let l:searchdir = join(l:searchdirs, '/') . '/'
     for l:marker in ['.rootdir', '.git', '.hg', '.svn', 'bzr', '_darcs', 'build.xml']
-      " the forward slash works as a dirsep on Windows too.
-      let l:item = l:searchdir.'/'.l:marker
+      let l:item = l:searchdir . l:marker
       if filereadable(l:item) || isdirectory(l:item)
         " found it! Return the dir
         return l:searchdir


### PR DESCRIPTION
This always returns a trailing slash on the project root. Normally it's not required but when trying to `lcd` to the root directory on POSIX the empty string won't work and on Windows without the slash following a drive letter and a colon just switches to that volume but retains that drive's current directory.
